### PR TITLE
fix: update dependency got to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"ext-name": "^5.0.0",
 		"file-type": "^17.1.6",
 		"filenamify": "^5.0.2",
-		"got": "^11.8.5",
+		"got": "^12.6.0",
 		"os-filter-obj": "^2.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Reason: Typescript will fail to build if any other dependency relies on `got@12`.
Related TS issue: https://github.com/microsoft/TypeScript/issues/11917
In short: [`got@11` installs `@types` packages as regular dependencies](https://github.com/sindresorhus/got/blob/2b1482ca847867cbf24abde4d68e8063611e50d1/package.json#L49) that shadow already typed packages from newer version.

Minimal repro:
```sh
mkdir ./repro-ts && cd ./repro-ts && \
    npm init -f && \
    npm i -D typescript && \
    npm i -S got@12 @mole-inc/bin-wrapper && \
    touch main.ts && \
    npx --package typescript tsc main.ts --noEmit
```

<details>
<summary>Output</summary>

```
node_modules/@types/cacheable-request/index.d.ts:26:42 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

26         cb?: (response: ServerResponse | ResponseLike) => void
                                            ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:77:51 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

77             listener: (response: ServerResponse | ResponseLike) => void
                                                     ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:81:69 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

81         on(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
                                                                       ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:84:71 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

84         once(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
                                                                         ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:89:51 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

89             listener: (response: ServerResponse | ResponseLike) => void
                                                     ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:95:51 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

95             listener: (response: ServerResponse | ResponseLike) => void
                                                     ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:104:51 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

104             listener: (response: ServerResponse | ResponseLike) => void
                                                      ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:108:70 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

108         off(event: 'response', listener: (response: ServerResponse | ResponseLike) => void): this;
                                                                         ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:112:73 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

112         listeners(event: 'response'): Array<(response: ServerResponse | ResponseLike) => void>;
                                                                            ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:115:76 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

115         rawListeners(event: 'response'): Array<(response: ServerResponse | ResponseLike) => void>;
                                                                               ~~~~~~~~~~~~

node_modules/@types/cacheable-request/index.d.ts:118:60 - error TS2709: Cannot use namespace 'ResponseLike' as a type.

118         emit(event: 'response', response: ServerResponse | ResponseLike): boolean;
                                                               ~~~~~~~~~~~~


Found 11 errors in the same file, starting at: node_modules/@types/cacheable-request/index.d.ts:26

```
</details>